### PR TITLE
更新工作流

### DIFF
--- a/.github/scripts/nightlyBuildProcess.js
+++ b/.github/scripts/nightlyBuildProcess.js
@@ -13,4 +13,5 @@ tomlObject.package.metadata.loglevel.release = "trace";
 tomlObject.package.metadata.loglevel.releaseFrontend = "trace";
 
 const newContent = toml.stringify(tomlObject);
+console.log(newContent);
 fs.writeFileSync(cargoPath, newContent);

--- a/.github/workflows/Nightly Build.yml
+++ b/.github/workflows/Nightly Build.yml
@@ -45,8 +45,9 @@ jobs:
           $hash = git rev-parse --short HEAD
           $sourcePath = Get-ChildItem -Path "App/src-tauri/target/release/bundle/nsis" -File | Select-Object -First 1
           $newName = "Techclass-nightly-${date}-${hash}$($sourcePath.Extension)"
+          $uploadName = "Techclass-nightly-${date}-${hash}"
           Rename-Item -Path $sourcePath.FullName -NewName $newName
-          "ARTIFACT_NAME=$newName" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "ARTIFACT_NAME=$uploadName" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: upload
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This pull request includes minor changes to the nightly build process in the `.github/scripts/nightlyBuildProcess.js` and `.github/workflows/Nightly Build.yml` files. The changes focus on adding a console log for debugging purposes and modifying the artifact naming convention.

Changes to `.github/scripts/nightlyBuildProcess.js`:

* Added a `console.log` statement to output the new content of the `tomlObject` for debugging purposes.

Changes to `.github/workflows/Nightly Build.yml`:

* Modified the artifact naming process by introducing a new variable `uploadName` to standardize the name used for uploading the artifact.